### PR TITLE
feat: Adapt NVDA output device switching for NVDA 2025.1+ mmdevice API

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description": _("An add-on of NVDA for system audio management."),
 	# version
-	"addon_version": "1.0.7",
+	"addon_version": "1.0.8",
 	# Author(s)
 	"addon_author": "huaiyinfeilong <huaiyinfeilong@163.com>",
 	# URL for the add-on documentation support
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2022.4",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2024.1",
+	"addon_lastTestedNVDAVersion": "2025.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Description:

This PR updates the NVDA audio output device switching mechanism to support the new `mmdevice`-based API introduced in NVDA 2025.1, while maintaining backward compatibility with older versions using the legacy `nvwave` API.

## Key Changes:

*   Implemented version detection (`IS_NVDA_2025_1_OR_LATER`) to determine the appropriate API.
*   Introduced `_MMDevice_NVDAOutputDeviceNavigator` to handle audio device management using `utils.mmdevice` for NVDA 2025.1+.
*   Refactored the existing `nvwave`-based logic into `_Legacy_NVDAOutputDeviceNavigator`.
*   Added `NVDAOutputDeviceNavigator` as an adapter class that dynamically selects and delegates to the correct implementation based on the running NVDA version.
*   Performed minor code refactoring and import cleanup for better organization.
